### PR TITLE
Fix invalid selection reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,6 +170,7 @@
 
       if (!isSameRow || !isConsecutive) {
         alert('Only consecutive bars in the same row can be struck.');
+        bars.forEach(bar => bar.classList.remove('hover-path'));
         return;
       }
 


### PR DESCRIPTION
## Summary
- reset all selected bars when an invalid strike is attempted

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844321f74cc832c9d30034130d5ccf8